### PR TITLE
Update to common build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches: [master]
 
 env:
-  Configuration: Release
   Artifacts: ${{ github.workspace }}/out
   Logs: ${{ github.workspace }}/out/logs
   Tests: ${{ github.workspace }}/out/tests
@@ -25,9 +24,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - run: dotnet build -bl:"${{ env.Logs }}/build.binLog"
-      - run: dotnet test --no-build test/Tests.csproj -bl:"${{ env.Logs }}/test.binLog"
-      - run: dotnet pack --no-build src/Fuzzy.csproj -bl:"${{ env.Logs }}/pack.binLog"
+      - run: dotnet restore
+      - run: dotnet test -c Debug --no-restore -bl:"${{ env.Logs }}/test.binLog"
+      - run: dotnet build -c Release --no-restore -bl:"${{ env.Logs }}/build.binLog"
+      - run: dotnet pack -c Release --no-build -bl:"${{ env.Logs }}/pack.binLog"
       - name: Locate Codecov input files (workaround for files glob not working on Windows)
         if: always()
         id: test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,42 @@
-# clone
-This repository contains submodules and symlinks.
+# Clone
+
+- _Include submodules and symlinks_.
 ```PowerShell
 git clone --recurse-submodules -c core.symlinks=true https://github.com/olegsych/fuzzy.git
 ```
 
-# build
+If you already cloned without `--recurse-submodules`, initialize them manually:
 ```PowerShell
-dotnet build ./Fuzzy.slnx
+git submodule update --init --recursive
 ```
 
-# test
+The build depends on symlinked files from the `modules/csharp.common` submodule. Without it the build will fail.
+
+# Build
+
+_Build the `Release` configuration for full build-time validation_.
 ```PowerShell
-dotnet test --project ./test/Tests.csproj
-wsl -e dotnet test --project ./test/Tests.csproj
+dotnet build -c Release
 ```
+
+# Test
+
+- _Run tests in the default `Debug` configuration on all frameworks and platforms_.
+  Tests may require `#if DEBUG` hooks and fail with `-c Release`.
+  ```PowerShell
+  dotnet test
+  wsl -e dotnet test
+  ```
+
+- _Troubleshoot specific projects, target frameworks, tests, including explicit tests_
+  ```PowerShell
+  dotnet run --project ./examples/Examples.csproj -f net10.0 -- -reporter verbose -namespace * -class * -method * -explicit on
+  ```
+
+# Pack
+
+```PowerShell
+dotnet pack
+```
+
+This builds the `Release` configuration by default and creates NuGet packages in the `out/packages/` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ dotnet build -c Release
   wsl -e dotnet test
   ```
 
-- _Troubleshoot specific projects, target frameworks, tests, including explicit tests_
+- _Troubleshoot specific projects, target frameworks, and tests (including explicit tests)_
   ```PowerShell
   dotnet run --project ./examples/Examples.csproj -f net10.0 -- -reporter verbose -namespace * -class * -method * -explicit on
   ```


### PR DESCRIPTION
build.yml is now copied from csharp.common. In combination with the new symlinked Directory.Build.props and Directory.Build.targets it allows to build, test and pack the entire solution instead of individual projects.

CONTRIBUTING.md explains how to troubleshoot tests.